### PR TITLE
Improve zabbix template trigger - ensures will trigger on degraded

### DIFF
--- a/zbx_export_templates.xml
+++ b/zbx_export_templates.xml
@@ -442,7 +442,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template MD RAID:mdraid[{#MD_DEVICE},e,&quot;State&quot;].regexp(&quot;(clean|active)&quot;)}=0</expression>
+                            <expression>{Template MD RAID:mdraid[{#MD_DEVICE},e,&quot;State&quot;].regexp(&quot;(degraded|resyncing|recovering|Not Started)&quot;)}=1</expression>
                             <name>{#MD_DEVICE} RAID State</name>
                             <url/>
                             <status>0</status>


### PR DESCRIPTION
I've had a look at the open issue and I'm pretty sure this needs to change. I'm seeing the template currently on master failing to trigger for "active,resyncing". This presumably means that it will not trigger on "active,degraded" like in [this sort of output](http://www.linuxquestions.org/questions/linux-general-1/mdadm-active-degraded-what-do-i-do-646716/). That is, no trigger for a degraded array. I've changed my copy to just look for all the [worrying keywords](https://superuser.com/questions/162395/possible-mdadm-raid-states) and now it's doing what I want. :)
